### PR TITLE
Type fixes for Debounce

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,12 +5,12 @@
     "**/.svn": true,
     "**/.hg": true,
     "**/.DS_Store": true,
-    "**/node_modules": false,
+    "**/node_modules": true,
     "*.d.ts": true,
     "*.js": true
   },
   "search.exclude": {
-    "**/node_modules": false,
+    "**/node_modules": true,
     "**/bower_components": true,
     "*.d.ts": true,
     "*.js": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,12 +5,12 @@
     "**/.svn": true,
     "**/.hg": true,
     "**/.DS_Store": true,
-    "**/node_modules": true,
+    "**/node_modules": false,
     "*.d.ts": true,
     "*.js": true
   },
   "search.exclude": {
-    "**/node_modules": true,
+    "**/node_modules": false,
     "**/bower_components": true,
     "*.d.ts": true,
     "*.js": true

--- a/config/tslint/full.json
+++ b/config/tslint/full.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "tslint-config-shopify"
-  ]
+  ],
+  "rules": {
+    "match-default-export-name": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/lodash": "^4.14.65",
+    "@types/lodash-es": "^4.14.5",
     "in-publish": "^2.0.0",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "@types/react": "^15.0.21",
-    "lodash": "^4.17.4"
+    "lodash-es": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/lodash": "^4.14.65",
     "in-publish": "^2.0.0",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/lodash": "^4.14.65",
     "@types/lodash-es": "^4.14.5",
     "in-publish": "^2.0.0",
     "npm-run-all": "^4.0.2",

--- a/src/decorators/debounce.ts
+++ b/src/decorators/debounce.ts
@@ -1,4 +1,10 @@
-import lodashDebounce, {DebounceSettings} from 'lodash/debounce';
+import lodashDebounce from 'lodash/debounce';
+
+export interface DebounceSettings {
+    leading?: boolean,
+    maxWait?: number,
+    trailing?: boolean,
+}
 
 export default function debounce(wait = 500, options?: DebounceSettings) {
   return function(target: any, key: string, descriptor: PropertyDescriptor) {

--- a/src/decorators/debounce.ts
+++ b/src/decorators/debounce.ts
@@ -1,12 +1,7 @@
-import debounce from 'lodash-es/debounce';
+import lodashDebounce from 'lodash-es/debounce';
+import {DebounceSettings} from 'lodash';
 
-export interface DebounceSettings {
-  leading?: boolean,
-  maxWait?: number,
-  trailing?: boolean,
-}
-
-export default function debounceDecorator(wait = 500, options?: DebounceSettings) {
+export default function debounce(wait = 500, options?: DebounceSettings) {
   return function(target: any, key: string, descriptor: PropertyDescriptor) {
     const functionToDebounce = descriptor.value;
 
@@ -21,7 +16,7 @@ export default function debounceDecorator(wait = 500, options?: DebounceSettings
           return functionToDebounce;
         }
 
-        const boundFunction = debounce(functionToDebounce, wait, options);
+        const boundFunction = lodashDebounce(functionToDebounce, wait, options);
         definingProperty = true;
 
         Object.defineProperty(this, key, {

--- a/src/decorators/debounce.ts
+++ b/src/decorators/debounce.ts
@@ -1,4 +1,4 @@
-import lodashDebounce from 'lodash/debounce';
+import debounce from 'lodash/debounce';
 
 export interface DebounceSettings {
     leading?: boolean,
@@ -6,7 +6,7 @@ export interface DebounceSettings {
     trailing?: boolean,
 }
 
-export default function debounce(wait = 500, options?: DebounceSettings) {
+export default function debounceDecorator(wait = 500, options?: DebounceSettings) {
   return function(target: any, key: string, descriptor: PropertyDescriptor) {
     const functionToDebounce = descriptor.value;
 
@@ -21,7 +21,7 @@ export default function debounce(wait = 500, options?: DebounceSettings) {
           return functionToDebounce;
         }
 
-        const boundFunction = lodashDebounce(functionToDebounce, wait, options);
+        const boundFunction = debounce(functionToDebounce, wait, options);
         definingProperty = true;
 
         Object.defineProperty(this, key, {

--- a/src/decorators/debounce.ts
+++ b/src/decorators/debounce.ts
@@ -1,9 +1,9 @@
-import debounce from 'lodash/debounce';
+import debounce from 'lodash-es/debounce';
 
 export interface DebounceSettings {
-    leading?: boolean,
-    maxWait?: number,
-    trailing?: boolean,
+  leading?: boolean,
+  maxWait?: number,
+  trailing?: boolean,
 }
 
 export default function debounceDecorator(wait = 500, options?: DebounceSettings) {

--- a/src/decorators/memoize.ts
+++ b/src/decorators/memoize.ts
@@ -1,6 +1,6 @@
-import loadashMemoize from 'lodash/memoize';
+import memoize from 'lodash/memoize';
 
-export default function memoize(resolver?: Function) {
+export default function memoizeDecorator(resolver?: Function) {
   return function(target: any, key: string, descriptor: PropertyDescriptor) {
     const functionToMemoize = descriptor.value;
 
@@ -15,7 +15,7 @@ export default function memoize(resolver?: Function) {
           return functionToMemoize;
         }
 
-        const boundFunction = loadashMemoize(functionToMemoize, resolver);
+        const boundFunction = memoize(functionToMemoize, resolver);
         definingProperty = true;
 
         Object.defineProperty(this, key, {

--- a/src/decorators/memoize.ts
+++ b/src/decorators/memoize.ts
@@ -1,6 +1,6 @@
-import memoize from 'lodash-es/memoize';
+import lodashMemoize from 'lodash-es/memoize';
 
-export default function memoizeDecorator(resolver?: Function) {
+export default function memoize(resolver?: Function) {
   return function(target: any, key: string, descriptor: PropertyDescriptor) {
     const functionToMemoize = descriptor.value;
 
@@ -15,7 +15,7 @@ export default function memoizeDecorator(resolver?: Function) {
           return functionToMemoize;
         }
 
-        const boundFunction = memoize(functionToMemoize, resolver);
+        const boundFunction = lodashMemoize(functionToMemoize, resolver);
         definingProperty = true;
 
         Object.defineProperty(this, key, {

--- a/src/decorators/memoize.ts
+++ b/src/decorators/memoize.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash/memoize';
+import memoize from 'lodash-es/memoize';
 
 export default function memoizeDecorator(resolver?: Function) {
   return function(target: any, key: string, descriptor: PropertyDescriptor) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,13 @@
 # yarn lockfile v1
 
 
-"@types/lodash@^4.14.65":
+"@types/lodash-es@^4.14.5":
+  version "4.14.5"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.14.5.tgz#57c11845eaf6a7d2a9095e9533fed4980f3d5784"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
   version "4.14.65"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.65.tgz#a0f78d71ffcd3c02628d5f616410c98c424326d5"
 
@@ -419,9 +425,9 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
-lodash@^4.17.4:
+lodash-es@^4.17.4:
   version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
 lowercase-keys@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/lodash@^4.14.65":
+  version "4.14.65"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.65.tgz#a0f78d71ffcd3c02628d5f616410c98c424326d5"
+
 "@types/react@^15.0.21":
   version "15.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.21.tgz#29d849427237c1463abfb7b370755ee3e5b5b375"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
+"@types/lodash@*", "@types/lodash@^4.14.65":
   version "4.14.65"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.65.tgz#a0f78d71ffcd3c02628d5f616410c98c424326d5"
 


### PR DESCRIPTION
Was getting this error when importing
`import {DebounceSettings} from 'lodash/debounce';`.
Not sure why `yarn run check` didn't catch it.
Also added `@types/lodash`

'"/Users/utkarshsaxena/src/github.com/Shopify/Neutron/node_modules/@types/lodash/debounce/index"' resolves to a non-module entity and cannot be imported using this construct.