### PR TITLE
[Docs] changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
 # Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ## [2.0.0] - 2017-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2017-07-27
+### Added
+- Adds a `CHANGELOG` to document changes moving forward.
+
+### Changed
+- The `autobind` decorator is now in the `decorators` directory.
+    - **WARNING** any existing imports must be changed accordingly:
+```ts
+// old way
+import autobind from '@shopify/javascript-utilities/autobind';
+
+// new way
+import {autobind} from '@shopify/javascript-utilities/decorators';
+```
+- Updated documentation in `README.md` and `CONTRIBUTING.md`.
+
+### Fixed
+- Multiple decorators can now be used simultaneously (ex. `autobind` with `debounce`).
+
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.6...v2.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,4 +39,8 @@ changing arguments to a function, adding a new function, changing the
 return value, etc), please ensure the documentation is also updated to
 reflect this. Documentation is in the `README.md` if further documentation is needed please communicate via Github Issues.
 
-**IMPORTANT** Also, please make sure you update the changelog, which can be found in `CHANGELOG.md`.
+## Changelog
+Please make sure you update `CHANGELOG.md` with a high-level description of any changes you make. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## Releasing a new version
+The `yarn version` command can be used to create a new version. This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,5 @@ If your change affects how people use the project (i.e. adding or
 changing arguments to a function, adding a new function, changing the
 return value, etc), please ensure the documentation is also updated to
 reflect this. Documentation is in the `README.md` if further documentation is needed please communicate via Github Issues.
+
+**IMPORTANT** Also, please make sure you update the changelog, which can be found in `CHANGELOG.md`.


### PR DESCRIPTION
Adds a `CHANGELOG` based on the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) specification v1.0.0.

I like the fact that this is a formal specification that describes how a changelog should be put together. I feel like this will make it easier to update the changelog in the future, as well as keep our language consistent.