### PR TITLE
Adds a fancy new README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
-# javascript-utilities
+<div align="center">
+  <h1>javascript-utilities</h1>
+  <h4>A set of utilities for JavaScript and TypeScript projects at Shopify.</h4>
+  <a href="https://circleci.com/gh/Shopify/javascript-utilities">
+    <img src="https://circleci.com/gh/Shopify/javascript-utilities.svg?style=shield"
+         alt="CircleCI">
+  </a>
+  <a href="https://badge.fury.io/js/%40shopify%2Fjavascript-utilities">
+    <img src="https://badge.fury.io/js/%40shopify%2Fjavascript-utilities.svg" alt="npm version">
+  </a>
+  <a href="https://github.com/Shopify/javascript-utilities/blob/master/LICENSE.md">
+    <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT">
+  </a>
+</div>
 
-[![CircleCI](https://circleci.com/gh/Shopify/javascript-utilities.svg?style=svg)](https://circleci.com/gh/Shopify/javascript-utilities)
+## Table of Contents
 
-A set of utilities for JavaScript and TypeScript projects at Shopify.
+  - [Installation](#installation)
+  - [API](#api-reference)
+  - [Contribute](#contribute)
+  - [License](#license)
+  - [Changelog](http://github.com/Shopify/javascript-utilities/blob/master/CHANGELOG.md)
 
 ## Installation
 
@@ -10,12 +27,16 @@ A set of utilities for JavaScript and TypeScript projects at Shopify.
 $ yarn add @shopify/javascript-utilities
 ```
 
-## API
+## API Reference
 
 See the comments and TypeScript annotations in the code for details on the provided utilities.
 
+## Contribute
+
+Check out our [Contributing Guidelines](http://github.com/Shopify/javascript-utilities/blob/master/CONTRIBUTING.md)
+
 ## License
 
-MIT, see [LICENSE.md](http://github.com/Shopify/javascript-utilities/blob/master/LICENSE.md) for details.
+MIT &copy; [Shopify](https://shopify.com/), see [LICENSE.md](http://github.com/Shopify/javascript-utilities/blob/master/LICENSE.md) for details.
 
-<img src="https://cdn.shopify.com/shopify-marketing_assets/builds/19.0.0/shopify-full-color-black.svg" width="200" />
+<a href="http://www.shopify.com/"><img src="https://cdn.shopify.com/assets2/press/brand/shopify-logo-main-small-f029fcaf14649a054509f6790ce2ce94d1f1c037b4015b4f106c5a67ab033f5b.png" alt="Shopify" width="200" /></a>


### PR DESCRIPTION
After discussions with the team, I decided I would try my hand at a "nice" `README` file that may be good to turn into a template in the future.

## Inspiration
- https://github.com/matiassingers/awesome-readme
- https://medium.com/@meakaakka/a-beginners-guide-to-writing-a-kickass-readme-7ac01da88ab3

## Using an HTML header
I decided to go with an HTML header, because I noticed that the README files I liked in the `awesome-readme` repo all did this.

### Centred
I also liked the centred design better than a left-aligned version.

**Note** this is officially a markdown anti-pattern (as is any formatting); however, I don't think that's a big deal for GFM, since it's not "official" markdown. Also, seeing as how many READMEs are using this pattern (at least for the header), I don't see a problem with it.