### PR TITLE
[FastDOM] Adds clear function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 ## [Unreleased]
+- Adds `clear` function to `fastdom`. Usage:
+```ts
+import {write, read, clear} from '@shopify/javscript-utilities/fastdom';
+
+const writeTask = write(...);
+const readTask = read(..);
+
+// later
+clear(writeTask);
+clear(readTask);
+```
 
 ## [2.0.0] - 2017-07-27
 ### Added

--- a/src/fastdom.ts
+++ b/src/fastdom.ts
@@ -1,8 +1,14 @@
+export type TaskID = number;
+
 // for now we just use rAF but we should use some kind of fastDOM implementation
-export function read(callback: FrameRequestCallback): number {
+export function read(callback: FrameRequestCallback): TaskID {
   return requestAnimationFrame(callback);
 }
 
-export function write(callback: FrameRequestCallback): number {
+export function write(callback: FrameRequestCallback): TaskID {
   return requestAnimationFrame(callback);
+}
+
+export function clear(taskID: TaskID): void {
+  return cancelAnimationFrame(taskID);
 }


### PR DESCRIPTION
Building for the long term, this is the name used by fastdom, so if we eventually replace this with a fastdom implementation, it need not change the API: https://github.com/wilsonpage/fastdom#fastdomclearid