### PR TITLE
Adds a simplified way to create new method decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ clear(writeTask);
 clear(readTask);
 ```
 
+- Adds a `createMethodDecorator` utility to facillitate creating decorators
+for methods. It can handle all of the edge cases we have seen so far, such as binding,
+taking in arguments, and handling descrepancies in the property descriptor when used
+together with other decorators. Usage:
+```ts
+import {createMethodDecorator} from '@shopify/javascript-utilities/decorators/factory';
+
+export default createMethodDecorator((method, thisArg, ...decoratorArgs) => {
+  // return new method
+});
+
+```
+
 ## [2.0.0] - 2017-07-27
 ### Added
 - Adds a `CHANGELOG` to document changes moving forward.

--- a/src/decorators/factory.ts
+++ b/src/decorators/factory.ts
@@ -1,0 +1,28 @@
+import {DecoratorFactory, GenericDecorator, DecoratorConfig} from 'lodash-decorators';
+import {Applicator, ApplicateOptions} from 'lodash-decorators/applicators';
+
+/**
+ * A simplified version of a method decorator
+ */
+export interface SimpleMethodDecorator {
+  (method: Function, thisArg: object, ...decoratorArgs: any[]): any,
+}
+
+class GenericApplicator extends Applicator {
+  // tslint:disable-next-line prefer-function-over-method
+  apply({value, config: {execute}, args, instance}: ApplicateOptions): any {
+    if (!instance) {
+      return value;
+    }
+
+    return execute(value, instance, ...args);
+  }
+}
+
+/**
+ * A factory for creating decorators
+ */
+export function createMethodDecorator(simpleDecorator: SimpleMethodDecorator): GenericDecorator {
+  return DecoratorFactory.createInstanceDecorator(new DecoratorConfig(simpleDecorator, new GenericApplicator()));
+}
+


### PR DESCRIPTION
I wanted to create a `callback` decorator for `react-utilities`, and I realized that there are a lot of edge cases to handle for making our own decorators. As such, I made this utility to simplify the process.

To see this in action:
https://github.com/Shopify/react-utilities/pull/10