### PR TITLE
[focus] Updated focusable selector to match only non-disabled node(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Unreleased]
+- Updates `focus` functions to match only non-disabled nodes
 - Adds `clear` function to `fastdom`. Usage:
 ```ts
 import {write, read, clear} from '@shopify/javscript-utilities/fastdom';

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -1,6 +1,6 @@
 import {matches} from './dom';
 
-export const FOCUSABLE_SELECTOR = 'a,frame,iframe,input:not([type=hidden]),select,textarea,button,*[tabindex]';
+export const FOCUSABLE_SELECTOR = 'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
 
 export function findFirstFocusableNode(element: HTMLElement, onlyDescendants = true): HTMLElement | null {
   if (!onlyDescendants && matches(element, FOCUSABLE_SELECTOR)) { return element; }


### PR DESCRIPTION
### Why are these changes being introduced?
closes https://github.com/Shopify/javascript-utilities/issues/30

### What is this pull request doing?
Fixes a bug in accessibility when the first or last focusable selector is disabled. 