### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,3 @@
-director: kpeatt
 owners:
   - lemonmade
   - GoodForOneFare


### PR DESCRIPTION
**Owners**: @lemonmade @GoodForOneFare @ismail-syed
**Service**: [javascript-utilities/production](https://services.shopify.io/services/javascript-utilities/production)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
