### PR TITLE
Fixed getNewRange function

### DIFF
--- a/src/dates.ts
+++ b/src/dates.ts
@@ -122,19 +122,19 @@ export function getNewRange(range: Range | undefined, selected: Date): Range {
 
   const {start, end} = range;
 
-  if (end && start !== end) {
+  if (end && (isDateAfter(start, end) || isDateBefore(start, end))) {
     return {start: selected, end: selected};
   }
 
   if (start) {
-    if (selected < start) {
+    if (isDateBefore(selected, start)) {
       return {start: selected, end: selected};
     }
     return {start, end: selected};
   }
 
   if (end) {
-    if (selected < end) {
+    if (isDateBefore(selected, end)) {
       return {start: selected, end};
     }
     return {start: start || end, end: selected};

--- a/src/tests/dates.test.ts
+++ b/src/tests/dates.test.ts
@@ -1,4 +1,4 @@
-import { Weekdays, getWeeksForMonth, abbreviationForWeekday } from '../dates';
+import { Weekdays, getWeeksForMonth, abbreviationForWeekday, getNewRange } from '../dates';
 
 describe('abbreviationForWeekday()', () => {
   it('abbreviates the word correctly', () => {
@@ -61,5 +61,25 @@ describe('getWeeksForMonth()', () => {
     expect(weeks[0][4]).toBeNull();
     expect(weeks[0][5]).toBeNull();
     expect(weeks[0][6]).not.toBeNull();
+  });
+});
+
+describe('getNewRange()', () => {
+  it('returns a new range with end date in the future', () => {
+    // startDate and endDate are the same date but have different references for
+    // test purposes
+    const startDate = new Date('01 Jan 2018 00:00:00 GMT');
+    const endDate = new Date('01 Jan 2018 00:00:00 GMT');
+    const futureDate = new Date('05 Jan 2018 00:00:00 GMT');
+
+    const range = {
+      start: startDate,
+      end: endDate,
+    };
+
+    expect(getNewRange(range, futureDate)).toEqual({
+      start: startDate,
+      end: futureDate,
+    });
   });
 });


### PR DESCRIPTION
`getNewRange` was returning the wrong result when comparing two different dates since they had different object references.

I'm using current utility functions to do better date comparison.

This change fixes the way we can use polaris Datepickers.
Here is a PR that has a broken behaviour when using current polaris Datepicker: https://github.com/Shopify/web/pull/8192