### PR TITLE
Improve isSameDay function and add tests

### DIFF
--- a/src/dates.ts
+++ b/src/dates.ts
@@ -108,10 +108,13 @@ export function dateIsSelected(day: Date | null, range: Range) {
 }
 
 export function isSameDay(day1: Date, day2: Date) {
+  const unoffsettedDay1 = unapplyTimezoneOffset(day1);
+  const unoffsettedDay2 = unapplyTimezoneOffset(day2);
+
   return (
-    (day1.getDate() === day2.getDate()) &&
-    (day1.getMonth() === day2.getMonth()) &&
-    (day1.getFullYear() === day2.getFullYear())
+    (unoffsettedDay1.getDate() === unoffsettedDay2.getDate()) &&
+    (unoffsettedDay1.getMonth() === unoffsettedDay2.getMonth()) &&
+    (unoffsettedDay1.getFullYear() === unoffsettedDay2.getFullYear())
   );
 }
 
@@ -218,4 +221,9 @@ function getOrderedWeekdays(weekStartsOn: Weekdays): Weekdays[] {
   const weekDays = [...WEEKDAYS];
   const restOfDays = weekDays.splice(weekStartsOn);
   return [...restOfDays, ...weekDays];
+}
+
+
+function unapplyTimezoneOffset(day: Date) {
+  return new Date(day.valueOf() + (day.getTimezoneOffset() * 60 * 1000));
 }

--- a/src/tests/dates.test.ts
+++ b/src/tests/dates.test.ts
@@ -6,6 +6,7 @@ import {
   isSameMonthAndYear,
   isToday,
   isYesterday,
+  isSameDay,
   Weekdays,
 } from '../dates';
 
@@ -215,5 +216,19 @@ describe('isYesterday', () => {
     const differentYear = new Date(yesterday.getTime());
     differentYear.setFullYear(yesterday.getFullYear() + 1);
     expect(isYesterday(differentYear)).toBe(false);
+  });
+});
+
+describe('isSameDay', () => {
+  it('returns true for dates of same day even if time is different', () => {
+    const morning = new Date('01 Jan 2018 00:00:00 GMT');
+    const afterNoon = new Date('01 Jan 2018 23:59:59 GMT');
+    expect(isSameDay(morning, afterNoon)).toBe(true);
+  });
+
+  it('returns false for dates of different day', () => {
+    const morning = new Date('01 Jan 2018 00:00:00 GMT');
+    const afterNoon = new Date('02 Jan 2018 00:00:01 GMT');
+    expect(isSameDay(morning, afterNoon)).toBe(false);
   });
 });


### PR DESCRIPTION
Right now, `isSameDay` will fail if comparing two dates from a different timezone. Eg.
`new Date('01 Jan 2018 00:00:00 GMT')` and `new Date('01 Jan 2018 23:59:59 GMT')` will not be on the same day, because we are on EST, so `new Date('01 Jan 2018 00:00:00 GMT')` will actually be `Dec 31`