### PR TITLE
Add date comparison functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-[//]: # '## [Unreleased]'
+## [Unreleased]
+
+### Added
+
+- [Dates] New helper functions: `getDateDiff`, `isLessThanOneMinuteAgo`, `isLessThanOneHourAgo`, `isLessThanOneDayAgo`, `isLessThanOneWeekAgo`, and `isLessThanOneYearAgo`.
 
 ## [2.3.0] - 2018-11-15
 
@@ -57,7 +61,8 @@ import {autobind} from '@shopify/javascript-utilities/decorators';
 
 ---
 
-[unreleased]: https://github.com/shopify/javascript-utilities/compare/v2.2.1...HEAD
+[unreleased]: https://github.com/shopify/javascript-utilities/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/shopify/javascript-utilities/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/shopify/javascript-utilities/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/shopify/javascript-utilities/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/shopify/javascript-utilities/compare/v2.0.0...v2.1.0

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -23,6 +23,15 @@ export enum Months {
   December,
 }
 
+export enum TimeUnit {
+  Second = 1000,
+  Minute = Second * 60,
+  Hour = Minute * 60,
+  Day = Hour * 24,
+  Week = Day * 7,
+  Year = Day * 365,
+}
+
 export interface Range {
   start: Date,
   end: Date,
@@ -115,6 +124,10 @@ export function isSameDay(day1: Date, day2: Date) {
   );
 }
 
+export function getDateDiff(resolution: TimeUnit, date: Date, today = new Date()) {
+  return Math.floor((today.getTime() - date.getTime()) / resolution);
+}
+
 export function getNewRange(range: Range | undefined, selected: Date): Range {
   if (range == null) {
     return {start: selected, end: selected};
@@ -177,6 +190,26 @@ export function isDateAfter(date: Date, dateToCompare: Date) {
 
 export function isDateBefore(date: Date, dateToCompare: Date) {
   return date.getTime() < dateToCompare.getTime();
+}
+
+export function isLessThanOneMinuteAgo(date: Date, today = new Date()) {
+  return today.getTime() - date.getTime() < TimeUnit.Minute;
+}
+
+export function isLessThanOneHourAgo(date: Date, today = new Date()) {
+  return today.getTime() - date.getTime() < TimeUnit.Hour;
+}
+
+export function isLessThanOneDayAgo(date: Date, today = new Date()) {
+  return today.getTime() - date.getTime() < TimeUnit.Day;
+}
+
+export function isLessThanOneWeekAgo(date: Date, today = new Date()) {
+  return today.getTime() - date.getTime() < TimeUnit.Week;
+}
+
+export function isLessThanOneYearAgo(date: Date, today = new Date()) {
+  return today.getTime() - date.getTime() < TimeUnit.Year;
 }
 
 export function isSameMonthAndYear(source: Date, target: Date) {

--- a/src/tests/dates.test.ts
+++ b/src/tests/dates.test.ts
@@ -29,14 +29,9 @@ describe('abbreviationForWeekday()', () => {
 });
 
 describe('getDateDiff()', () => {
-  let now;
-  let testDate;
-
-  beforeEach(() => {
-    now = new Date();
-    testDate = new Date(now.getTime());
-    testDate.setFullYear(now.getFullYear() - 1);
-  });
+  const now = new Date();
+  const testDate = new Date(now.getTime());
+  testDate.setFullYear(now.getFullYear() - 1);
 
   it('returns expected diff in seconds', () => {
     const diff = getDateDiff(TimeUnit.Second, testDate, now);

--- a/src/tests/dates.test.ts
+++ b/src/tests/dates.test.ts
@@ -1,11 +1,18 @@
 import {
   abbreviationForWeekday,
+  getDateDiff,
   getNewRange,
   getWeeksForMonth,
+  isLessThanOneMinuteAgo,
+  isLessThanOneHourAgo,
+  isLessThanOneDayAgo,
+  isLessThanOneWeekAgo,
+  isLessThanOneYearAgo,
   isSameDate,
   isSameMonthAndYear,
   isToday,
   isYesterday,
+  TimeUnit,
   Weekdays,
 } from '../dates';
 
@@ -18,6 +25,79 @@ describe('abbreviationForWeekday()', () => {
     expect(abbreviationForWeekday(Weekdays.Thursday)).toBe('Th');
     expect(abbreviationForWeekday(Weekdays.Friday)).toBe('Fr');
     expect(abbreviationForWeekday(Weekdays.Saturday)).toBe('Sa');
+  });
+});
+
+describe('getDateDiff()', () => {
+  let now;
+  let testDate;
+
+  beforeEach(() => {
+    now = new Date();
+    testDate = new Date(now.getTime());
+    testDate.setFullYear(now.getFullYear() - 1);
+  });
+
+  it('returns expected diff in seconds', () => {
+    const diff = getDateDiff(TimeUnit.Second, testDate, now);
+    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Second);
+  });
+
+  it('returns expected diff in minutes', () => {
+    const diff = getDateDiff(TimeUnit.Minute, testDate, now);
+    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Minute);
+  });
+
+  it('returns expected diff in hours', () => {
+    const diff = getDateDiff(TimeUnit.Hour, testDate, now);
+    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Hour);
+  });
+
+  it('returns expected diff in days', () => {
+    const diff = getDateDiff(TimeUnit.Day, testDate, now);
+    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Day);
+  });
+
+  it('returns expected diff in weeks', () => {
+    const diff = getDateDiff(TimeUnit.Week, testDate, now);
+    expect(diff).toEqual(Math.floor(TimeUnit.Year / TimeUnit.Week));
+  });
+
+  it('returns expected diff in years', () => {
+    const diff = getDateDiff(TimeUnit.Year, testDate, now);
+    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Year);
+  });
+
+  describe('second date defaults to today', () => {
+    it('returns expected diff in seconds', () => {
+      const diff = getDateDiff(TimeUnit.Second, testDate);
+      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Second);
+    });
+
+    it('returns expected diff in minutes', () => {
+      const diff = getDateDiff(TimeUnit.Minute, testDate);
+      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Minute);
+    });
+
+    it('returns expected diff in hours', () => {
+      const diff = getDateDiff(TimeUnit.Hour, testDate);
+      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Hour);
+    });
+
+    it('returns expected diff in days', () => {
+      const diff = getDateDiff(TimeUnit.Day, testDate);
+      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Day);
+    });
+
+    it('returns expected diff in weeks', () => {
+      const diff = getDateDiff(TimeUnit.Week, testDate);
+      expect(diff).toEqual(Math.floor(TimeUnit.Year / TimeUnit.Week));
+    });
+
+    it('returns expected diff in years', () => {
+      const diff = getDateDiff(TimeUnit.Year, testDate);
+      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Year);
+    });
   });
 });
 
@@ -90,6 +170,121 @@ describe('getNewRange()', () => {
       start: startDate,
       end: futureDate,
     });
+  });
+});
+
+describe('isLessThanOneMinuteAgo', () => {
+  it('returns false for dates more than one minute apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setSeconds(now.getSeconds() - 61);
+    expect(isLessThanOneMinuteAgo(other, now)).toBe(false);
+  });
+
+  it('returns false for dates exactly one minute apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setSeconds(now.getSeconds() - 60);
+    expect(isLessThanOneMinuteAgo(other, now)).toBe(false);
+  });
+
+  it('returns true for dates less than one minute apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setSeconds(now.getSeconds() - 59);
+    expect(isLessThanOneMinuteAgo(other, now)).toBe(true);
+  });
+});
+
+describe('isLessThanOneHourAgo', () => {
+  it('returns false for dates more than one hour apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setMinutes(now.getMinutes() - 61);
+    expect(isLessThanOneHourAgo(other, now)).toBe(false);
+  });
+
+  it('returns false for dates exactly one hour apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setMinutes(now.getMinutes() - 60);
+    expect(isLessThanOneHourAgo(other, now)).toBe(false);
+  });
+
+  it('returns true for dates less than one hour apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setMinutes(now.getMinutes() - 59);
+    expect(isLessThanOneHourAgo(other, now)).toBe(true);
+  });
+});
+
+describe('isLessThanOneDayAgo', () => {
+  it('returns false for dates more than one day apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setHours(now.getHours() - 25);
+    expect(isLessThanOneDayAgo(other, now)).toBe(false);
+  });
+
+  it('returns false for dates exactly one day apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setHours(now.getHours() - 24);
+    expect(isLessThanOneDayAgo(other, now)).toBe(false);
+  });
+
+  it('returns true for dates less than one day apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setHours(now.getHours() - 23);
+    expect(isLessThanOneDayAgo(other, now)).toBe(true);
+  });
+});
+
+describe('isLessThanOneWeekAgo', () => {
+  it('returns false for dates more than one week apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setDate(now.getDate() - 8);
+    expect(isLessThanOneWeekAgo(other, now)).toBe(false);
+  });
+
+  it('returns false for dates exactly one week apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setDate(now.getDate() - 7);
+    expect(isLessThanOneWeekAgo(other, now)).toBe(false);
+  });
+
+  it('returns true for dates less than one week apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setDate(now.getDate() - 6);
+    expect(isLessThanOneWeekAgo(other, now)).toBe(true);
+  });
+});
+
+describe('isLessThanOneYearAgo', () => {
+  it('returns false for dates more than one year apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setDate(now.getDate() - 366);
+    expect(isLessThanOneYearAgo(other, now)).toBe(false);
+  });
+
+  it('returns false for dates exactly one year apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setDate(now.getDate() - 365);
+    expect(isLessThanOneYearAgo(other, now)).toBe(false);
+  });
+
+  it('returns true for dates less than one year apart', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setDate(now.getDate() - 364);
+    expect(isLessThanOneYearAgo(other, now)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Add new comparison functions:
- `isLessThanOneMinuteAgo`
- `isLessThanOneHourAgo`
- `isLessThanOneDayAgo`
- `isLessThanOneWeekAgo`
- `isLessThanOneYearAgo`

Extracted from https://github.com/Shopify/quilt/pull/405/files.