### PR TITLE
move @types/react to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "@types/jest": "^23.1.5",
     "@types/lodash-decorators": "^4.0.0",
+    "@types/lodash": "^4.14.65",
+    "@types/react": "^16.0.2",
     "in-publish": "^2.0.0",
     "jest": "^23.4.0",
     "npm-run-all": "^4.0.2",
@@ -35,8 +37,6 @@
     "typescript": "^2.5.3"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.65",
-    "@types/react": "^16.0.2",
     "lodash": "^4.17.4",
     "lodash-decorators": "^4.3.5"
   },


### PR DESCRIPTION
@types/react in dependencies is problematic as it often results in multiple conflicting versions.