### PR TITLE
Prevent false positives for future dates in `isLessThan*` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!--## [Unreleased]-->
 
+## [2.4.1] - 2019-08-20
+
+### Fixed
+
+- [Dates] `isLessThan*` functions no longer return false positives when passed dates in the future.
+
 ## [2.4.0] - 2019-01-04
 
 ### Added
@@ -63,7 +69,8 @@ import {autobind} from '@shopify/javascript-utilities/decorators';
 
 ---
 
-[unreleased]: https://github.com/shopify/javascript-utilities/compare/v2.4.0...HEAD
+[unreleased]: https://github.com/shopify/javascript-utilities/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/shopify/javascript-utilities/compare/v2.3.0...v2.4.1
 [2.4.0]: https://github.com/shopify/javascript-utilities/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/shopify/javascript-utilities/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/shopify/javascript-utilities/compare/v2.2.0...v2.2.1

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -193,23 +193,23 @@ export function isDateBefore(date: Date, dateToCompare: Date) {
 }
 
 export function isLessThanOneMinuteAgo(date: Date, today = new Date()) {
-  return today.getTime() - date.getTime() < TimeUnit.Minute;
+  return (isDateBefore(date, today) && today.getTime() - date.getTime() < TimeUnit.Minute);
 }
 
 export function isLessThanOneHourAgo(date: Date, today = new Date()) {
-  return today.getTime() - date.getTime() < TimeUnit.Hour;
+  return (isDateBefore(date, today) && today.getTime() - date.getTime() < TimeUnit.Hour);
 }
 
 export function isLessThanOneDayAgo(date: Date, today = new Date()) {
-  return today.getTime() - date.getTime() < TimeUnit.Day;
+  return (isDateBefore(date, today) && today.getTime() - date.getTime() < TimeUnit.Day);
 }
 
 export function isLessThanOneWeekAgo(date: Date, today = new Date()) {
-  return today.getTime() - date.getTime() < TimeUnit.Week;
+  return (isDateBefore(date, today) && today.getTime() - date.getTime() < TimeUnit.Week);
 }
 
 export function isLessThanOneYearAgo(date: Date, today = new Date()) {
-  return today.getTime() - date.getTime() < TimeUnit.Year;
+  return (isDateBefore(date, today) && today.getTime() - date.getTime() < TimeUnit.Year);
 }
 
 export function isSameMonthAndYear(source: Date, target: Date) {

--- a/src/tests/dates.test.ts
+++ b/src/tests/dates.test.ts
@@ -169,6 +169,13 @@ describe('getNewRange()', () => {
 });
 
 describe('isLessThanOneMinuteAgo', () => {
+  it('returns false for dates in the future', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setFullYear(now.getFullYear() + 1);
+    expect(isLessThanOneMinuteAgo(other, now)).toBe(false);
+  });
+
   it('returns false for dates more than one minute apart', () => {
     const now = new Date();
     const other = new Date(now.getTime());
@@ -192,6 +199,13 @@ describe('isLessThanOneMinuteAgo', () => {
 });
 
 describe('isLessThanOneHourAgo', () => {
+  it('returns false for dates in the future', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setFullYear(now.getFullYear() + 1);
+    expect(isLessThanOneHourAgo(other, now)).toBe(false);
+  });
+
   it('returns false for dates more than one hour apart', () => {
     const now = new Date();
     const other = new Date(now.getTime());
@@ -215,6 +229,13 @@ describe('isLessThanOneHourAgo', () => {
 });
 
 describe('isLessThanOneDayAgo', () => {
+  it('returns false for dates in the future', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setFullYear(now.getFullYear() + 1);
+    expect(isLessThanOneDayAgo(other, now)).toBe(false);
+  });
+
   it('returns false for dates more than one day apart', () => {
     const now = new Date();
     const other = new Date(now.getTime());
@@ -238,6 +259,13 @@ describe('isLessThanOneDayAgo', () => {
 });
 
 describe('isLessThanOneWeekAgo', () => {
+  it('returns false for dates in the future', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setFullYear(now.getFullYear() + 1);
+    expect(isLessThanOneWeekAgo(other, now)).toBe(false);
+  });
+
   it('returns false for dates more than one week apart', () => {
     const now = new Date();
     const other = new Date(now.getTime());
@@ -261,6 +289,13 @@ describe('isLessThanOneWeekAgo', () => {
 });
 
 describe('isLessThanOneYearAgo', () => {
+  it('returns false for dates in the future', () => {
+    const now = new Date();
+    const other = new Date(now.getTime());
+    other.setFullYear(now.getFullYear() + 1);
+    expect(isLessThanOneYearAgo(other, now)).toBe(false);
+  });
+
   it('returns false for dates more than one year apart', () => {
     const now = new Date();
     const other = new Date(now.getTime());


### PR DESCRIPTION
Fix `isLessThan*` functions to return `false` for dates in the future.

Future dates cause the time diff to be negative which always passes the `isLessThan*` conditions.