### PR TITLE
Add new date helper function 'isTomorrow'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!--## [Unreleased]-->
 
+## [2.5.0] - 2020-05-22
+
+### Added
+
+- [Dates] New helper functions: `isTomorrow`, and `isLeapYear`.
+
+### Fixed
+
+- [Dates] `getDateDiff` test to work for Leap Years.
+
 ## [2.4.1] - 2019-08-20
 
 ### Fixed
@@ -69,7 +79,8 @@ import {autobind} from '@shopify/javascript-utilities/decorators';
 
 ---
 
-[unreleased]: https://github.com/shopify/javascript-utilities/compare/v2.4.1...HEAD
+[unreleased]: https://github.com/shopify/javascript-utilities/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/shopify/javascript-utilities/compare/v2.3.0...v2.5.0
 [2.4.1]: https://github.com/shopify/javascript-utilities/compare/v2.3.0...v2.4.1
 [2.4.0]: https://github.com/shopify/javascript-utilities/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/shopify/javascript-utilities/compare/v2.2.1...v2.3.0

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -237,6 +237,17 @@ export function isYesterday(date: Date) {
   return isSameDate(yesterday, date);
 }
 
+export function isTomorrow(date: Date) {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  return isSameDate(tomorrow, date);
+}
+
+export function isLeapYear(year: Year) {
+  return (year % 400 === 0) || ((year % 4 === 0) && (year % 100 !== 0));
+}
+
 const WEEKDAYS = [
   Weekdays.Sunday,
   Weekdays.Monday,

--- a/src/tests/dates.test.ts
+++ b/src/tests/dates.test.ts
@@ -12,6 +12,8 @@ import {
   isSameMonthAndYear,
   isToday,
   isYesterday,
+  isTomorrow,
+  isLeapYear,
   TimeUnit,
   Weekdays,
 } from '../dates';
@@ -32,66 +34,69 @@ describe('getDateDiff()', () => {
   const now = new Date();
   const testDate = new Date(now.getTime());
   testDate.setFullYear(now.getFullYear() - 1);
+  const timeUnitYear = isLeapYear(now.getFullYear())
+  ? TimeUnit.Day * 366
+  : TimeUnit.Year;
 
   it('returns expected diff in seconds', () => {
     const diff = getDateDiff(TimeUnit.Second, testDate, now);
-    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Second);
+    expect(diff).toEqual(timeUnitYear / TimeUnit.Second);
   });
 
   it('returns expected diff in minutes', () => {
     const diff = getDateDiff(TimeUnit.Minute, testDate, now);
-    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Minute);
+    expect(diff).toEqual(timeUnitYear / TimeUnit.Minute);
   });
 
   it('returns expected diff in hours', () => {
     const diff = getDateDiff(TimeUnit.Hour, testDate, now);
-    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Hour);
+    expect(diff).toEqual(timeUnitYear / TimeUnit.Hour);
   });
 
   it('returns expected diff in days', () => {
     const diff = getDateDiff(TimeUnit.Day, testDate, now);
-    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Day);
+    expect(diff).toEqual(timeUnitYear / TimeUnit.Day);
   });
 
   it('returns expected diff in weeks', () => {
     const diff = getDateDiff(TimeUnit.Week, testDate, now);
-    expect(diff).toEqual(Math.floor(TimeUnit.Year / TimeUnit.Week));
+    expect(diff).toEqual(Math.floor(timeUnitYear / TimeUnit.Week));
   });
 
   it('returns expected diff in years', () => {
-    const diff = getDateDiff(TimeUnit.Year, testDate, now);
-    expect(diff).toEqual(TimeUnit.Year / TimeUnit.Year);
+    const diff = getDateDiff(timeUnitYear, testDate, now);
+    expect(diff).toEqual(timeUnitYear / timeUnitYear);
   });
 
   describe('second date defaults to today', () => {
     it('returns expected diff in seconds', () => {
       const diff = getDateDiff(TimeUnit.Second, testDate);
-      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Second);
+      expect(diff).toEqual(timeUnitYear / TimeUnit.Second);
     });
 
     it('returns expected diff in minutes', () => {
       const diff = getDateDiff(TimeUnit.Minute, testDate);
-      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Minute);
+      expect(diff).toEqual(timeUnitYear / TimeUnit.Minute);
     });
 
     it('returns expected diff in hours', () => {
       const diff = getDateDiff(TimeUnit.Hour, testDate);
-      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Hour);
+      expect(diff).toEqual(timeUnitYear / TimeUnit.Hour);
     });
 
     it('returns expected diff in days', () => {
       const diff = getDateDiff(TimeUnit.Day, testDate);
-      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Day);
+      expect(diff).toEqual(timeUnitYear / TimeUnit.Day);
     });
 
     it('returns expected diff in weeks', () => {
       const diff = getDateDiff(TimeUnit.Week, testDate);
-      expect(diff).toEqual(Math.floor(TimeUnit.Year / TimeUnit.Week));
+      expect(diff).toEqual(Math.floor(timeUnitYear / TimeUnit.Week));
     });
 
     it('returns expected diff in years', () => {
-      const diff = getDateDiff(TimeUnit.Year, testDate);
-      expect(diff).toEqual(TimeUnit.Year / TimeUnit.Year);
+      const diff = getDateDiff(timeUnitYear, testDate);
+      expect(diff).toEqual(timeUnitYear / timeUnitYear);
     });
   });
 });
@@ -440,5 +445,71 @@ describe('isYesterday', () => {
     const differentYear = new Date(yesterday.getTime());
     differentYear.setFullYear(yesterday.getFullYear() + 1);
     expect(isYesterday(differentYear)).toBe(false);
+  });
+});
+
+describe('isTomorrow', () => {
+  it('returns true for dates with same day, month, and year as the day after today', () => {
+    const today = new Date();
+    const tomorrow = new Date(today.getTime());
+    tomorrow.setDate(today.getDate() + 1);
+    expect(isTomorrow(tomorrow)).toBe(true);
+
+    // Time is irrelevant
+    const differentMinutes = new Date(tomorrow.getTime());
+    differentMinutes.setMinutes(tomorrow.getMinutes() + 1);
+    expect(isTomorrow(differentMinutes)).toBe(true);
+
+    const differentHours = new Date(tomorrow.getTime());
+    differentHours.setHours(tomorrow.getHours() + 1);
+    expect(isTomorrow(differentHours)).toBe(true);
+  });
+
+  it('returns false for dates with different day, month, or year from today', () => {
+    const today = new Date();
+    const tomorrow = new Date(today.getTime());
+    tomorrow.setDate(today.getDate() + 1);
+
+    const differentDay = new Date(tomorrow.getTime());
+    differentDay.setDate(tomorrow.getDate() + 1);
+    expect(isTomorrow(differentDay)).toBe(false);
+
+    const differentMonth = new Date(tomorrow.getTime());
+    differentMonth.setMonth(tomorrow.getMonth() + 1);
+    expect(isTomorrow(differentMonth)).toBe(false);
+
+    const differentYear = new Date(tomorrow.getTime());
+    differentYear.setFullYear(tomorrow.getFullYear() + 1);
+    expect(isTomorrow(differentYear)).toBe(false);
+  });
+});
+
+describe('isLeapYear', () => {
+  it('returns false for year divisible by 4 and 100 but not divisible by 400', () => {
+    const now = new Date();
+    now.setFullYear(1900);
+    const year = now.getFullYear();
+    expect(isLeapYear(year)).toBe(false);
+  });
+
+  it('returns false for year not divisible by 4, 100 or 400', () => {
+    const now = new Date();
+    now.setFullYear(1241);
+    const year = now.getFullYear();
+    expect(isLeapYear(year)).toBe(false);
+  });
+
+  it('returns true for year divisible by 4, but not divisible by 400 and 100', () => {
+    const now = new Date();
+    now.setFullYear(2020);
+    const year = now.getFullYear();
+    expect(isLeapYear(year)).toBe(true);
+  });
+
+  it('returns true for year divisible by 4, 100 and 400', () => {
+    const now = new Date();
+    now.setFullYear(2000);
+    const year = now.getFullYear();
+    expect(isLeapYear(year)).toBe(true);
   });
 });


### PR DESCRIPTION
Added `isTomorrow` helper function for future humanize 'today' dates. Also, I noticed that the tests failed, locally even when I switched to master. After debugging, I figured out it was because 2020 was a leap year. Hence, I updated the tests to work properly with leap year. 

In addition, I added `isLeapYear` helper function to identify if a year is a leap year. 

**Question** should how should the TimeUnit handle leap years?

https://github.com/Shopify/javascript-utilities/blob/80890c67d8052b5a1c2656921780a74b0ed72042/src/dates.ts#L32